### PR TITLE
[FR-5] Implement Capture Piece

### DIFF
--- a/Checkers/Board/BoardView.swift
+++ b/Checkers/Board/BoardView.swift
@@ -21,7 +21,7 @@ struct BoardView: View {
           if viewModel.selectedPosition == currentPosition {
             Color.green.opacity(0.2)
           }
-          if viewModel.possibleMoves.contains(currentPosition) {
+          if viewModel.validMoves.contains(currentPosition) {
             PieceView(size: size.width/10, color: Color.green.opacity(0.2))
               .blur(radius: 1)
           }

--- a/Checkers/Board/BoardViewModel.swift
+++ b/Checkers/Board/BoardViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 final class BoardViewModel: ObservableObject {
   @Published var pieces = Pieces.start
   @Published var selectedPosition: GridPosition?
-  @Published var possibleMoves = Set<GridPosition>()
+  @Published var validMoves = Set<GridPosition>()
   private var starterPlayerTurn = true
   
   func tapOn(position: GridPosition) {
@@ -14,8 +14,11 @@ final class BoardViewModel: ObservableObject {
         select(piece, at: position)
       } else {
         if let piece = pieces.first(where: { $0.isAt(position: selectedPosition) }),
-            piece.validMoves(for: pieces).contains(position) {
-          move(piece, to: position)
+           let move = piece.validMoves(for: pieces).first(where: {$0.destination == position }) {
+          movePiece(piece, to: move.destination)
+          if let capturedPiece = pieces.first(where: { $0.position == move.capturePosition}) {
+            pieces.remove(capturedPiece)
+          }
         }
       }
     } else {
@@ -29,15 +32,15 @@ final class BoardViewModel: ObservableObject {
   
   func select(_ piece: Piece, at position: GridPosition) {
     selectedPosition = position
-    possibleMoves = piece.validMoves(for: pieces)
+    validMoves = Set(piece.validMoves(for: pieces).map({$0.destination}))
   }
   
   func clearSelection() {
     selectedPosition = nil
-    possibleMoves = []
+    validMoves = []
   }
   
-  func move(_ piece: Piece, to position: GridPosition) {
+  func movePiece(_ piece: Piece, to position: GridPosition) {
     pieces.remove(piece)
     let newPositionPiece = Piece(starterPlayer: piece.starterPlayer, position: position)
     pieces.insert(newPositionPiece)

--- a/Checkers/Board/GridPosition.swift
+++ b/Checkers/Board/GridPosition.swift
@@ -1,25 +1,20 @@
+enum Direction {
+  case upLeft
+  case upRight
+  case downLeft
+  case downRight
+}
+
 struct GridPosition: Equatable, Hashable {
   let x: Int
   let y: Int
   
-  var adjacents: Set<GridPosition> {
-    var moves = Set<GridPosition>()
-    if y-1 >= 0 {
-      if x-1 >= 0 {
-        moves.insert(GridPosition(x: x-1, y: y-1))
-      }
-      if x+1 <= 8 {
-        moves.insert(GridPosition(x: x+1, y: y-1))
-      }
+  func nextPosition(_ direction: Direction) -> GridPosition? {
+    switch direction {
+    case .upLeft: return y-1 >= 0 && x-1 >= 0 ? GridPosition(x: x-1, y: y-1) : nil
+    case .upRight: return y-1 >= 0 && x+1 <= 7 ? GridPosition(x: x+1, y: y-1) : nil
+    case .downLeft: return y+1 <= 7 && x-1 >= 0 ? GridPosition(x: x-1, y: y+1) : nil
+    case .downRight: return y+1 <= 7 && x+1 <= 7 ? GridPosition(x: x+1, y: y+1) : nil
     }
-    if y+1 <= 8 {
-      if x-1 >= 0 {
-        moves.insert(GridPosition(x: x-1, y: y+1))
-      }
-      if x+1 <= 8 {
-        moves.insert(GridPosition(x: x+1, y: y+1))
-      }
-    }
-    return moves
   }
 }

--- a/Checkers/Views/Piece/Move.swift
+++ b/Checkers/Views/Piece/Move.swift
@@ -1,0 +1,8 @@
+struct Move: Hashable {
+  let destination: GridPosition
+  var capturePosition: GridPosition?
+  
+  var isCapture: Bool {
+    capturePosition != nil
+  }
+}

--- a/Checkers/Views/Piece/Piece.swift
+++ b/Checkers/Views/Piece/Piece.swift
@@ -18,7 +18,7 @@ struct Piece: Hashable {
   }
   
   func possibleMoves(for pieces: Pieces) -> Set<Move> {
-    var validMoves = Set([
+    let validMoves = Set([
       nextMove(at: starterPlayer ? .upLeft : .downLeft, on: pieces),
       nextMove(at: starterPlayer ? .upRight : .downRight, on: pieces),
       nextMove(at: starterPlayer ? .downLeft : .upLeft, on: pieces, shouldBeACapture: true),
@@ -40,11 +40,10 @@ private extension Piece {
     guard let piece = pieces.first(where: { $0.position == nextPosition }) else {
       return shouldBeACapture ? nil : Move(destination: nextPosition)
     }
-    if piece.starterPlayer != starterPlayer,
-       let positionAfterJump = piece.position.nextPosition(direction),
-       !pieces.containsPiece(at: positionAfterJump) {
-      return Move(destination: positionAfterJump, capturePosition: nextPosition)
-    }
-    return nil
+    guard piece.starterPlayer != starterPlayer,
+          let positionAfterJump = piece.position.nextPosition(direction),
+          !pieces.containsPiece(at: positionAfterJump) else { return nil }
+      
+    return Move(destination: positionAfterJump, capturePosition: nextPosition)
   }
 }

--- a/Checkers/Views/Piece/Pieces.swift
+++ b/Checkers/Views/Piece/Pieces.swift
@@ -29,4 +29,17 @@ extension Set where Element == Piece {
       Piece(starterPlayer: true, position: GridPosition(x: 6, y: 5))
     ]
   }()
+  
+  func containsPiece(at position: GridPosition) -> Bool {
+    map({$0.position}).contains(position)
+  }
+  
+  func containsCaptureMoveForOthersThan(_ targetPiece: Piece, starterPlayer: Bool) -> Bool {
+    for piece in filter({ $0.starterPlayer == starterPlayer && $0 != targetPiece }) {
+      if piece.possibleMoves(for: self).contains(where: { $0.isCapture }) {
+        return true
+      }
+    }
+    return false
+  }
 }

--- a/Checkers/Views/Piece/Pieces.swift
+++ b/Checkers/Views/Piece/Pieces.swift
@@ -31,7 +31,7 @@ extension Set where Element == Piece {
   }()
   
   func containsPiece(at position: GridPosition) -> Bool {
-    map({$0.position}).contains(position)
+    contains { $0.position == position }
   }
   
   func containsCaptureMoveForOthersThan(_ targetPiece: Piece, starterPlayer: Bool) -> Bool {


### PR DESCRIPTION
Closes #5

## Summary by Sourcery

Implements the ability for pieces to capture opponent pieces by jumping over them. This includes updating the logic for determining valid moves to prioritize capture moves and removing captured pieces from the board.