### PR TITLE
[FR-6] Implement multi-capture and refactor turn management

### DIFF
--- a/Checkers/Board/BoardViewModel.swift
+++ b/Checkers/Board/BoardViewModel.swift
@@ -60,5 +60,6 @@ final class BoardViewModel: ObservableObject {
   func changeTurn() {
     clearSelection()
     starterPlayerTurn.toggle()
+    isMultiCapturing = false
   }
 }


### PR DESCRIPTION
Closes #6

## Summary by Sourcery

Implements multi-capture functionality for checkers pieces, allowing a player to continue capturing pieces in a single turn if the opportunity arises. Also, refactors the turn change logic into its own function.