### PR TITLE
[FR-22] Play against computer

### DIFF
--- a/Checkers/Home/HomeView.swift
+++ b/Checkers/Home/HomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeView: View {
   @State var startNewGame = false
+  @State var isVsComputer = false
   var body: some View {
     ZStack {
       LinearGradient(gradient: Gradient(colors: [.black, .brown]), startPoint: .topLeading, endPoint: .bottomTrailing)
@@ -24,14 +25,26 @@ struct HomeView: View {
           HStack(spacing: 16) {
             PieceView(size: 50, color: .lightPiece, type: .default)
             Button {
+              isVsComputer = true
               startNewGame = true
             } label: {
-              Text("Play Game")
+              Text("vs Computer")
                 .frame(maxWidth: .infinity, maxHeight: 40)
             }
             .buttonStyle(MenuButtonStyle())
             PieceView(size: 50, color: Color.black, type: .default)
-            
+          }
+          HStack(spacing: 16) {
+            PieceView(size: 50, color: .black, type: .king)
+            Button {
+              isVsComputer = false
+              startNewGame = true
+            } label: {
+              Text("2 Players")
+                .frame(maxWidth: .infinity, maxHeight: 40)
+            }
+            .buttonStyle(MenuButtonStyle())
+            PieceView(size: 50, color: Color.lightPiece, type: .king)
           }
           HStack(spacing: 16) {
             PieceView(size: 50, color: .black, type: .king)
@@ -63,7 +76,7 @@ struct HomeView: View {
       .padding(16)
     }
     .fullScreenCover(isPresented: $startNewGame) {
-      MatchView(showGameScreen: $startNewGame)
+      MatchView(isVsComputer: isVsComputer, showGameScreen: $startNewGame)
     }
   }
 }

--- a/Checkers/Match/MatchView.swift
+++ b/Checkers/Match/MatchView.swift
@@ -1,9 +1,15 @@
 import SwiftUI
 
 struct MatchView: View {
-  @StateObject var viewModel = MatchViewModel()
+  @StateObject private var viewModel: MatchViewModel
   @Binding var showGameScreen: Bool
   @State var showAlertExitConfirmation = false
+
+  init(isVsComputer: Bool = false, showGameScreen: Binding<Bool>) {
+    self._viewModel = StateObject(wrappedValue: MatchViewModel(isVsComputer: isVsComputer))
+    self._showGameScreen = showGameScreen
+  }
+
   var body: some View {
     GeometryReader { proxy in
       VStack {
@@ -50,5 +56,5 @@ struct MatchView: View {
 
 #Preview {
   @Previewable @State var showGameScreen = true
-  MatchView(viewModel: MatchViewModel(), showGameScreen: $showGameScreen)
+  MatchView(showGameScreen: $showGameScreen)
 }

--- a/Checkers/Match/MatchViewModel.swift
+++ b/Checkers/Match/MatchViewModel.swift
@@ -77,16 +77,16 @@ final class MatchViewModel: ObservableObject {
     }
   }
 
-  func computerMove(_ piece: Piece, to position: GridPosition) async {
-    try? await Task.sleep(nanoseconds: 500_000_000)
+  private func computerMove(_ piece: Piece, to position: GridPosition) async {
+    try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
     lastMovePositions = [piece.position, position]
     withAnimation {
       piece.move(to: position)
     }
   }
 
-  func computerRemove(_ piece: Piece) async {
-    try? await Task.sleep(nanoseconds: 500_000_000)
+  private func computerRemove(_ piece: Piece) async {
+    try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
     withAnimation {
       pieces.removeAll(where: { $0.id == piece.id })
     }
@@ -113,7 +113,7 @@ final class MatchViewModel: ObservableObject {
     }
   }
 
-  func checkComputerTurn() async {
+  private func checkComputerTurn() async {
     guard !Task.isCancelled else { return }
     guard !isFirstPlayerTurn else { return }
 

--- a/Checkers/Match/MatchViewModel.swift
+++ b/Checkers/Match/MatchViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 final class MatchViewModel: ObservableObject {
   @Published var pieces = Pieces.start
   @Published var selectedPosition: GridPosition?
@@ -9,6 +10,7 @@ final class MatchViewModel: ObservableObject {
   @Published var isEndGame = false
   let isVsComputer: Bool
   private var isMultiCapturing = false
+  private var computerTask: Task<Void, Never>?
 
   init(isVsComputer: Bool = false) {
     self.isVsComputer = isVsComputer
@@ -49,105 +51,98 @@ final class MatchViewModel: ObservableObject {
       }
     }
   }
-  
+
   func select(_ piece: Piece, at position: GridPosition) {
     selectedPosition = position
     withAnimation {
       validMoves = piece.validMoves(for: pieces).map({$0.destination})
     }
   }
-  
+
   func clearSelection() {
     selectedPosition = nil
     validMoves = []
   }
-  
+
   func move(_ piece: Piece, to position: GridPosition) {
     lastMovePositions = [piece.position, position]
     withAnimation {
       piece.move(to: position)
     }
   }
-  
+
   func remove(_ piece: Piece) {
     withAnimation {
       pieces.removeAll(where: {$0.id == piece.id })
     }
   }
-  
+
   func computerMove(_ piece: Piece, to position: GridPosition) async {
-    try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 segundos
-    await MainActor.run {
-      self.lastMovePositions = [piece.position, position]
-      withAnimation {
-        piece.move(to: position)
-      }
+    try? await Task.sleep(nanoseconds: 500_000_000)
+    lastMovePositions = [piece.position, position]
+    withAnimation {
+      piece.move(to: position)
     }
   }
-  
+
   func computerRemove(_ piece: Piece) async {
-    try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 segundos
-    await MainActor.run {
-      withAnimation {
-        self.pieces.removeAll(where: { $0.id == piece.id })
-      }
+    try? await Task.sleep(nanoseconds: 500_000_000)
+    withAnimation {
+      pieces.removeAll(where: { $0.id == piece.id })
     }
   }
-  
+
   func changeTurn() {
     clearSelection()
     isMultiCapturing = false
-    
+
     pieces.forEach({$0.updateTypeIfNeeded()})
-    
+
     let enemyPieces = pieces.filter({$0.starterPlayer != isFirstPlayerTurn})
     let noValidMoves = !enemyPieces.contains(where: { $0.validMoves(for: pieces).isNotEmpty })
-    
+
     if noValidMoves {
       isEndGame = true
     } else {
       isFirstPlayerTurn.toggle()
       if isVsComputer {
-        Task {
+        computerTask = Task {
           await checkComputerTurn()
         }
       }
     }
   }
-  
+
   func checkComputerTurn() async {
+    guard !Task.isCancelled else { return }
     guard !isFirstPlayerTurn else { return }
-    
+
     let computerPieces = pieces.filter({$0.starterPlayer == false})
     let validPieces = computerPieces.filter({ $0.validMoves(for: pieces).isNotEmpty })
-    
+
     guard let piece = validPieces.randomElement() else { return }
     let validMoves = piece.validMoves(for: pieces)
     guard let movement = validMoves.randomElement() else { return }
     await computerMove(piece, to: movement.destination)
-    
+
     if movement.isCapture {
-      if let capturedPiece = pieces.first(where: { $0.position == movement.capturePosition}) {
+      if let capturedPiece = pieces.first(where: { $0.position == movement.capturePosition }) {
         await computerRemove(capturedPiece)
       }
-      while true {
-        if let newMove = piece.validMoves(for: pieces).first(where: { $0.isCapture }) {
-          await computerMove(piece, to: newMove.destination)
-          if let capturedPiece = pieces.first(where: { $0.position == newMove.capturePosition}) {
-            await computerRemove(capturedPiece)
-          }
-        } else {
-          break
+      while let newMove = piece.validMoves(for: pieces).first(where: { $0.isCapture }) {
+        await computerMove(piece, to: newMove.destination)
+        if let capturedPiece = pieces.first(where: { $0.position == newMove.capturePosition }) {
+          await computerRemove(capturedPiece)
         }
       }
     }
-    await MainActor.run {
-      self.changeTurn()
-    }
+    changeTurn()
   }
-  
+
   func restartGame() {
-    self.pieces = Pieces.start
+    computerTask?.cancel()
+    computerTask = nil
+    pieces = Pieces.start
     isFirstPlayerTurn = true
     clearSelection()
     isMultiCapturing = false

--- a/Checkers/Match/MatchViewModel.swift
+++ b/Checkers/Match/MatchViewModel.swift
@@ -7,10 +7,16 @@ final class MatchViewModel: ObservableObject {
   @Published var validMoves = [GridPosition]()
   @Published var isFirstPlayerTurn = true
   @Published var isEndGame = false
+  let isVsComputer: Bool
   private var isMultiCapturing = false
-  
+
+  init(isVsComputer: Bool = false) {
+    self.isVsComputer = isVsComputer
+  }
+
   func tapOn(position: GridPosition) {
     guard isEndGame == false else { return }
+    guard isFirstPlayerTurn || !isVsComputer else { return }
     if let selectedPosition {
       if let piece = pieces
         .filter({$0.starterPlayer == isFirstPlayerTurn})
@@ -69,6 +75,25 @@ final class MatchViewModel: ObservableObject {
     }
   }
   
+  func computerMove(_ piece: Piece, to position: GridPosition) async {
+    try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 segundos
+    await MainActor.run {
+      self.lastMovePositions = [piece.position, position]
+      withAnimation {
+        piece.move(to: position)
+      }
+    }
+  }
+  
+  func computerRemove(_ piece: Piece) async {
+    try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 segundos
+    await MainActor.run {
+      withAnimation {
+        self.pieces.removeAll(where: { $0.id == piece.id })
+      }
+    }
+  }
+  
   func changeTurn() {
     clearSelection()
     isMultiCapturing = false
@@ -82,6 +107,42 @@ final class MatchViewModel: ObservableObject {
       isEndGame = true
     } else {
       isFirstPlayerTurn.toggle()
+      if isVsComputer {
+        Task {
+          await checkComputerTurn()
+        }
+      }
+    }
+  }
+  
+  func checkComputerTurn() async {
+    guard !isFirstPlayerTurn else { return }
+    
+    let computerPieces = pieces.filter({$0.starterPlayer == false})
+    let validPieces = computerPieces.filter({ $0.validMoves(for: pieces).isNotEmpty })
+    
+    guard let piece = validPieces.randomElement() else { return }
+    let validMoves = piece.validMoves(for: pieces)
+    guard let movement = validMoves.randomElement() else { return }
+    await computerMove(piece, to: movement.destination)
+    
+    if movement.isCapture {
+      if let capturedPiece = pieces.first(where: { $0.position == movement.capturePosition}) {
+        await computerRemove(capturedPiece)
+      }
+      while true {
+        if let newMove = piece.validMoves(for: pieces).first(where: { $0.isCapture }) {
+          await computerMove(piece, to: newMove.destination)
+          if let capturedPiece = pieces.first(where: { $0.position == newMove.capturePosition}) {
+            await computerRemove(capturedPiece)
+          }
+        } else {
+          break
+        }
+      }
+    }
+    await MainActor.run {
+      self.changeTurn()
     }
   }
   


### PR DESCRIPTION
## Summary
- Add **vs Computer** and **2 Players** options to the main menu
- Implement AI that picks random valid moves, including captures and multi-jump
- Block player input during the computer's turn

## Changes
- `HomeView`: replaced single "Play Game" button with "vs Computer" and "2 Players"
- `MatchViewModel`: added `isVsComputer` flag; AI turn only triggers when enabled; player taps blocked during computer turn; fixed `while true` loop and comment typo
- `MatchView`: added `isVsComputer` init parameter; removed leftover `MyView` test code

## Test plan
- [ ] Tap "vs Computer" → game starts, computer plays as black after each player move
- [ ] Tap "2 Players" → game starts, no automatic moves
- [ ] Verify player cannot tap during computer turn
- [ ] Verify computer handles captures and multi-jump correctly
- [ ] Verify king promotion works for the computer
- [ ] Verify game end condition triggers correctly for both modes

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a vs-computer game mode with basic AI turn handling and integrate mode selection into the home screen.

New Features:
- Add a main menu option to start either a vs-computer match or a two-player match.
- Introduce a computer-controlled opponent that makes random valid moves, including captures and multi-jumps, when enabled.

Enhancements:
- Block user input during the computer's turn and automatically trigger the AI move sequence based on turn changes.
- Thread the vs-computer flag through HomeView and MatchView to configure MatchViewModel appropriately.