### PR TITLE
Install code-review plugin on interactive Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -35,6 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Install `code-review@claude-code-plugins` on the interactive `@claude` workflow
- Enables using the plugin via `@claude /code-review:code-review <repo>/pull/<number> --comment` to get inline PR review comments

## Usage
After merge, trigger inline review by commenting on a PR:
```
@claude /code-review:code-review sampaioroberto/CheckerSpell/pull/<number> --comment
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Install the code-review plugin on the interactive Claude GitHub workflow to enable inline PR review comments.

New Features:
- Enable code-review@claude-code-plugins within the @claude workflow for inline pull request reviews.

Build:
- Configure Claude GitHub Action to use the claude-code plugin marketplace and code-review plugin.

CI:
- Update Claude workflow permissions to allow writing to pull requests for posting review comments.