### PR TITLE
Try explicit allowedTools to enable inline PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,13 +17,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugin_marketplaces: 'anthropics/claude-code'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          claude_args: >-
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -35,6 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Explicitly allow `mcp__github_inline_comment__create_inline_comment` via `claude_args` so the plugin can post inline review comments
- Switch `plugin_marketplaces` to short format `anthropics/claude-code` (revert if it breaks)
- Change `fetch-depth` to `0` for full git history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure Claude Code GitHub workflows to support inline PR review comments and full repository context.

Build:
- Update claude-code-review workflow to fetch full git history and pass explicit allowed tools for inline review comments.
- Switch claude-code-review action to use the short plugin marketplace identifier for the Claude Code plugin.
- Grant write permissions on pull requests and configure plugin marketplace and plugins for the general claude workflow.