### PR TITLE
Revert code review workflow to stable config, keep fetch-depth: 0

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,8 +24,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'anthropics/claude-code'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          claude_args: >-
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Restore `plugin_marketplaces` to full URL `https://github.com/anthropics/claude-code.git`
- Remove `claude_args` override that was testing explicit tool allowlist
- Keep `fetch-depth: 0` for full git history during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update Claude code review workflow to use the full GitHub URL for the plugin marketplace and remove the temporary claude_args tool allowlist override.